### PR TITLE
chore: player GameMode should be 0-2, 6

### DIFF
--- a/en/LLSEPluginDevelopment/GameAPI/Player.md
+++ b/en/LLSEPluginDevelopment/GameAPI/Player.md
@@ -52,7 +52,7 @@ Each player object contains some fixed object properties. For a particular playe
 | pl.xuid                  | Player XUID String                                           | `String`         |
 | pl.uuid                  | Player Uuid string                                           | `String`         |
 | pl.permLevel             | Player's permission level (0 - 4)                            | `Integer`        |
-| pl.gameMode              | Player's game mode (0 - 3)                                   | `Integer`        |
+| pl.gameMode              | Player's game mode (0 - 2, 6)                                | `Integer`        |
 | pl.canSleep              | Whether the player can sleep                                 | `Boolean`        |
 | pl.canFly                | Whether the player can fly                                   | `Boolean`        |
 | pl.canBeSeenOnMap        | Whether the player can be seen on map                        | `Boolean`        |
@@ -774,7 +774,7 @@ pl.setPermLevel(1);
 - Parameters: 
 
   - mode : `Integer`  
-    Target game mode, `0` is survival mode, `1` is creative mode, `2` is adventure mode.
+    Target game mode, `0` is survival mode, `1` is creative mode, `2` is adventure mode. `6` is spectator mode.
 - Return value: Whether the modification was successful.
 - Return value type: `Boolean`
 

--- a/zh-Hans/LLSEPluginDevelopment/GameAPI/Player.md
+++ b/zh-Hans/LLSEPluginDevelopment/GameAPI/Player.md
@@ -52,7 +52,7 @@
 | pl.xuid                  | 玩家XUID字符串                    | `String`         |
 | pl.uuid                  | 玩家Uuid字符串                    | `String`         |
 | pl.permLevel             | 玩家的操作权限等级（0 - 4）       | `Integer`        |
-| pl.gameMode              | 玩家的游戏模式（0 - 2, 6）           | `Integer`        |
+| pl.gameMode              | 玩家的游戏模式（0 - 2, 6）          | `Integer`        |
 | pl.canFly                | 玩家是否可以飞行                  | `Boolean`        |
 | pl.canSleep              | 玩家是否可以睡觉                  | `Boolean`        |
 | pl.canBeSeenOnMap        | 玩家是否可以在地图上看到          | `Boolean`        |
@@ -990,7 +990,7 @@
 - 参数：
 
   - mode : `Integer`  
-    目标游戏模式，0为生存模式，1为创造模式，2为冒险模式
+    目标游戏模式，0为生存模式，1为创造模式，2为冒险模式, 3为观察者模式
 
 - 返回值：是否成功修改
 

--- a/zh-Hans/LLSEPluginDevelopment/GameAPI/Player.md
+++ b/zh-Hans/LLSEPluginDevelopment/GameAPI/Player.md
@@ -52,7 +52,7 @@
 | pl.xuid                  | 玩家XUID字符串                    | `String`         |
 | pl.uuid                  | 玩家Uuid字符串                    | `String`         |
 | pl.permLevel             | 玩家的操作权限等级（0 - 4）       | `Integer`        |
-| pl.gameMode              | 玩家的游戏模式（0 - 3）           | `Integer`        |
+| pl.gameMode              | 玩家的游戏模式（0 - 2, 6）           | `Integer`        |
 | pl.canFly                | 玩家是否可以飞行                  | `Boolean`        |
 | pl.canSleep              | 玩家是否可以睡觉                  | `Boolean`        |
 | pl.canBeSeenOnMap        | 玩家是否可以在地图上看到          | `Boolean`        |


### PR DESCRIPTION
## Descriptions
```
enum GameType : __int32{
      Survival = 0x0
      Creative = 0x1
      Adventure = 0x2
      Spectator = 0x6
};
```
## Issues Fixed

*No issues has been fixed by this PR*

## Type

- Mistake correction

## Statements

- My modification DOES NOT follow the style guidelines of this project.
- My modification IS dupliacted with other pull requests
- I have NOT read the [style guide](https://docs.litebds.com/en/#/Maintenance/StyleGuide).
- My modification IS involved with any copyright issues.
