### PR TITLE
fix typo 

### DIFF
--- a/zh-Hans/LLSEPluginDevelopment/EventAPI/BlockEvents.md
+++ b/zh-Hans/LLSEPluginDevelopment/EventAPI/BlockEvents.md
@@ -42,7 +42,7 @@
 
 <br>
 
-#### "onBlockExplode"` - 发生由方块引起的爆炸
+#### `"onBlockExplode"` - 发生由方块引起的爆炸
 
 - 监听函数原型
   `function(source,pos,radius,maxResistance,isDestroy,isFire)`


### PR DESCRIPTION
## Descriptions

方块事件中的”onBlockExplode”缺少”`”

## Issues Fixed

No issues has been fixed by this PR

## Type

Mistake correction