### PR TITLE
Update English Minecraft wiki references

### DIFF
--- a/en/LLSEPluginDevelopment/GameAPI/Basic.md
+++ b/en/LLSEPluginDevelopment/GameAPI/Basic.md
@@ -165,8 +165,8 @@ The return value is `0-3`, representing the four basic orientations of **North, 
 
 - Parameters:
 
-  - pos1 : `IntPos` diagonal coordinate 1, filled in similarly to the `from` parameter of the [fill command](https://minecraft.fandom.com/wiki/Command/fill "view in wikipedia")
-  - pos2 : `IntPos` diagonal coordinate 2, filled in similarly to the `to` parameter of the [fill command](https://minecraft.fandom.com/wiki/Command/fill "View in Wikipedia")
+  - pos1 : `IntPos` diagonal coordinate 1, filled in similarly to the `from` parameter of the [fill command](https://minecraft.wiki/w/Commands/fill "view in wikipedia")
+  - pos2 : `IntPos` diagonal coordinate 2, filled in similarly to the `to` parameter of the [fill command](https://minecraft.wiki/w/Commands/fill "View in Wikipedia")
   - ignoreBlocks : `Boolean` Ignore blocks
   - ignoreEntities : `Boolean` Ignore entities
 - Return value type : `NbtCompound`

--- a/en/LLSEPluginDevelopment/GameAPI/Block.md
+++ b/en/LLSEPluginDevelopment/GameAPI/Block.md
@@ -199,4 +199,4 @@ Through this function, set the block corresponding to one coordinate to another,
 - Return value: Whether it was successfully generated
 - Return value type: `Boolean`
 
-Particle effect names can be found in the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Particles#Types_of_particles), don't forget the namespace prefix when passing in parameters. similar to `minecraft:heart_particle`
+Particle effect names can be found in the [Minecraft Wiki](https://minecraft.wiki/w/Particles#Types_of_particles), don't forget the namespace prefix when passing in parameters. similar to `minecraft:heart_particle`

--- a/en/LLSEPluginDevelopment/NbtAPI/NBTCompound.md
+++ b/en/LLSEPluginDevelopment/NbtAPI/NBTCompound.md
@@ -211,7 +211,7 @@ If an item of Compound stores a `List` or `Compound` type NBT, it will recursive
 - Return value: The converted SNBT string.
 - Return value type: `String`
 
-> In addition to the normal binary NBT, another type of NBT that players are more familiar with is plain text, usually used in [commands](https://minecraft.fandom.com/wiki/Commands). This format is often referred to as **SNBT** (**Binary Named Tag,**, **S**tringified **NBT**)
+> In addition to the normal binary NBT, another type of NBT that players are more familiar with is plain text, usually used in [commands](https://minecraft.wiki/w/Commands). This format is often referred to as **SNBT** (**Binary Named Tag,**, **S**tringified **NBT**)
 >
 > --- Minecraft Wiki
 


### PR DESCRIPTION
## Descriptions

The English Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all Minecraft English wiki references accordingly.

*No issues has been fixed by this PR*

## Type

<!--- Remove the items not applying to your modification. -->

- Lexical or grammatical improvement

## Statements

<!--- Change these sentences to match your modifications. -->

- I have NOT read the [style guide](https://docs.litebds.com/en/#/Maintenance/StyleGuide) (link does not exist).
- My modification DOES follow the style guidelines of this project???
- My modification IS NOT duplicated with other pull requests
- My modification IS NOT involved with any copyright issues.
